### PR TITLE
Fix operator precedence issue

### DIFF
--- a/src/renderer.js
+++ b/src/renderer.js
@@ -873,7 +873,7 @@ Renderer.prototype = {
       currentStyle['fill']         = styles.fill        || styles.fillColor || styles.color;
       currentStyle['fill-opacity'] = styles.fillOpacity || styles.opacity   || '';
       currentStyle['fill-rule']    = styles.fillRule    ||
-        (feature.geometry.type === 'MultiPolygon') ? 'nonzero' : 'evenodd';
+        (feature.geometry.type === 'MultiPolygon' ? 'nonzero' : 'evenodd');
     } else {
       currentStyle['fill'] = 'none';
     }


### PR DESCRIPTION
There seems to be an operator precedence issue here:

https://github.com/w8r/geojson2svg/blob/f079c10ad3facf9f65aa6bacbd36e125433dafd5/src/renderer.js#L875-L876

Because of precedence, this code is interpreted like this:

```javascript
currentStyle['fill-rule'] = (styles.fillRule || 
   (feature.geometry.type === 'MultiPolygon')) ? 'nonzero' : 'evenodd'; 
```

Because of this, it's not possible to set `fill-rule` to `evenodd` for MultiPolygons. In order to fix it, parentheses should be moved like this:

```javascript
currentStyle['fill-rule'] = styles.fillRule || 
   (feature.geometry.type === 'MultiPolygon' ? 'nonzero' : 'evenodd'); 
```